### PR TITLE
AttributedTypeResolver - Adds locks to prevent concurrency issue

### DIFF
--- a/src/Our.Umbraco.Ditto/ComponentModel/Attributes/DittoProcessorAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Attributes/DittoProcessorAttribute.cs
@@ -21,7 +21,7 @@ namespace Our.Umbraco.Ditto
         {
             if (Ditto.TryGetTypeAttribute(this.GetType(), out DittoProcessorMetaDataAttribute metaData, true) == false || metaData == null)
             {
-                throw new ApplicationException("Ditto processor attributes require a DittoProcessorMetaData attribute to be applied to the class but none was found.");
+                throw new ApplicationException($"The Ditto processor attribute ('{this.GetType()}') requires a DittoProcessorMetaData attribute to be applied to the class but none was found.");
             }
 
             this.ValueType = metaData.ValueType;


### PR DESCRIPTION
Second attempt to fix #238 

---

I originally thought that using a `ConcurrentDictionary` would mitigate from the concurrency issue, as outlined in issue #238. But that doesn't appear to be the case.  I'm not sure why we'd want to use a `ConcurrentDictionary` if it's not working as expected - _which, is most likely due to my understanding of how it actually works._  This patch changes from using `ConcurrentDictionary` to a regular generic `Dictionary`, adding locks to prevent concurrently issues between reads/writes.